### PR TITLE
"Yandex metrika not initialized" error in script setup

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,25 +9,25 @@ import {
   startTracking,
 } from "./helpers.js";
 
-import type { Config, YaMetrika } from "./types.js";
+import type { Config } from "./types.js";
+import { YaMetrikaObject } from "./ya-object.js";
 
-let _metrikaInstance: YaMetrika | null = null;
+let _metrikaInstance = new YaMetrikaObject();
 
 export function initYandexMetrika(app: App, options: Config) {
-  app.config.globalProperties.$yandexMetrika = new EmptyYaMetrika();
+  const emptyMetrika = new EmptyYaMetrika();
+  _metrikaInstance.setMetrika(emptyMetrika);
+
+  app.config.globalProperties.$yandexMetrika = _metrikaInstance;
   updateConfig(options);
   checkConfig();
   loadScript(() => {
-    _metrikaInstance = createMetrika(app);
+    const metrika = createMetrika(app);
+    _metrikaInstance.setMetrika(metrika);
     startTracking(_metrikaInstance);
   }, options.scriptSrc);
 }
 
 export function useYandexMetrika() {
-  if (_metrikaInstance) {
-    return _metrikaInstance;
-  } else {
-    console.error("Yandex metrika has not been initialized");
-    return (_metrikaInstance = new EmptyYaMetrika());
-  }
+  return _metrikaInstance;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -59,7 +59,7 @@ declare global {
   }
 }
 
-declare interface SubParams {
+export declare interface SubParams {
   callback?: () => void;
   ctx?: any;
   params?: {

--- a/lib/ya-object.ts
+++ b/lib/ya-object.ts
@@ -15,17 +15,17 @@ export class YaMetrikaObject implements YaMetrika {
       return;
     }
 
-    this.addFileExtension = m.addFileExtension.bind(m);
-    this.extLink = m.extLink.bind(m);
-    this.file = m.file.bind(m);
-    this.getClientID = m.getClientID.bind(m);
-    this.hit = m.hit.bind(m);
-    this.notBounce = m.notBounce.bind(m);
-    this.params = m.params.bind(m);
-    this.reachGoal = m.reachGoal.bind(m);
-    this.replacePhones = m.replacePhones.bind(m);
-    this.setUserID = m.setUserID.bind(m);
-    this.userParams = m.userParams.bind(m);
+    this.addFileExtension = m.addFileExtension?.bind(m);
+    this.extLink = m.extLink?.bind(m);
+    this.file = m.file?.bind(m);
+    this.getClientID = m.getClientID?.bind(m);
+    this.hit = m.hit?.bind(m);
+    this.notBounce = m.notBounce?.bind(m);
+    this.params = m.params?.bind(m);
+    this.reachGoal = m.reachGoal?.bind(m);
+    this.replacePhones = m.replacePhones?.bind(m);
+    this.setUserID = m.setUserID?.bind(m);
+    this.userParams = m.userParams?.bind(m);
   }
 
   addFileExtension(vals: string | string[]): void {

--- a/lib/ya-object.ts
+++ b/lib/ya-object.ts
@@ -15,17 +15,17 @@ export class YaMetrikaObject implements YaMetrika {
       return;
     }
 
-    this.addFileExtension = m.addFileExtension;
-    this.extLink = m.extLink;
-    this.file = m.file;
-    this.getClientID = m.getClientID;
-    this.hit = m.hit;
-    this.notBounce = m.notBounce;
-    this.params = m.params;
-    this.reachGoal = m.reachGoal;
-    this.replacePhones = m.replacePhones;
-    this.setUserID = m.setUserID;
-    this.userParams = m.userParams;
+    this.addFileExtension = m.addFileExtension.bind(m);
+    this.extLink = m.extLink.bind(m);
+    this.file = m.file.bind(m);
+    this.getClientID = m.getClientID.bind(m);
+    this.hit = m.hit.bind(m);
+    this.notBounce = m.notBounce.bind(m);
+    this.params = m.params.bind(m);
+    this.reachGoal = m.reachGoal.bind(m);
+    this.replacePhones = m.replacePhones.bind(m);
+    this.setUserID = m.setUserID.bind(m);
+    this.userParams = m.userParams.bind(m);
   }
 
   addFileExtension(vals: string | string[]): void {

--- a/lib/ya-object.ts
+++ b/lib/ya-object.ts
@@ -1,0 +1,72 @@
+import { YaMetrika, SubParams } from "./types";
+
+export class YaMetrikaObject implements YaMetrika {
+  metrika: YaMetrika | null = null;
+
+  setMetrika(metrika: YaMetrika | null) {
+    this.metrika = metrika;
+
+    this._setFunctions();
+  }
+
+  private _setFunctions() {
+    const m = this.metrika;
+    if (!m) {
+      return;
+    }
+
+    this.addFileExtension = m.addFileExtension;
+    this.extLink = m.extLink;
+    this.file = m.file;
+    this.getClientID = m.getClientID;
+    this.hit = m.hit;
+    this.notBounce = m.notBounce;
+    this.params = m.params;
+    this.reachGoal = m.reachGoal;
+    this.replacePhones = m.replacePhones;
+    this.setUserID = m.setUserID;
+    this.userParams = m.userParams;
+  }
+
+  addFileExtension(vals: string | string[]): void {
+    throw new Error("Method not implemented.");
+  }
+
+  extLink(url: string, options?: SubParams | undefined): void {
+    throw new Error("Method not implemented.");
+  }
+  file(url: string, options?: SubParams | undefined): void {
+    throw new Error("Method not implemented.");
+  }
+  getClientID(callback: (clientID: string) => void): void {
+    throw new Error("Method not implemented.");
+  }
+  hit(url: string, options?: SubParams | undefined): void {
+    throw new Error("Method not implemented.");
+  }
+  notBounce(options?: { callback: () => void; ctx?: any } | undefined): void {
+    throw new Error("Method not implemented.");
+  }
+  params(parameters: any[] | { [key: string]: any }): void {
+    throw new Error("Method not implemented.");
+  }
+  reachGoal(
+    target: string,
+    params?:
+      | { order_price?: number | undefined; currency?: string | undefined }
+      | undefined,
+    callback?: (() => void) | undefined,
+    ctx?: any
+  ): void {
+    throw new Error("Method not implemented.");
+  }
+  replacePhones(): void {
+    throw new Error("Method not implemented.");
+  }
+  setUserID(userID: string): void {
+    throw new Error("Method not implemented.");
+  }
+  userParams(parameters: { [key: string]: any }): void {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/src/empty-ya.d.ts
+++ b/src/empty-ya.d.ts
@@ -1,0 +1,16 @@
+import type { Config, YaMetrika } from "./types.js";
+export declare class EmptyYaMetrika implements YaMetrika {
+    config: Config;
+    constructor();
+    addFileExtension(): void;
+    extLink(): void;
+    file(): void;
+    getClientID(): void;
+    hit(): void;
+    notBounce(): void;
+    params(): void;
+    reachGoal(): void;
+    replacePhones(): void;
+    setUserID(): void;
+    userParams(): void;
+}

--- a/src/empty-ya.js
+++ b/src/empty-ya.js
@@ -1,0 +1,61 @@
+import config from "./config.js";
+export class EmptyYaMetrika {
+    constructor() {
+        this.config = config;
+    }
+    addFileExtension() {
+        if (this.config.debug) {
+            console.log("[vue-yandex-metrika] addFileExtension:", arguments);
+        }
+    }
+    extLink() {
+        if (this.config.debug) {
+            console.log("[vue-yandex-metrika] extLink:", arguments);
+        }
+    }
+    file() {
+        if (this.config.debug) {
+            console.log("[vue-yandex-metrika] file:", arguments);
+        }
+    }
+    getClientID() {
+        if (this.config.debug) {
+            console.log("[vue-yandex-metrika] getClientID:", arguments);
+        }
+    }
+    hit() {
+        if (this.config.debug) {
+            console.log("[vue-yandex-metrika] hit:", arguments);
+        }
+    }
+    notBounce() {
+        if (this.config.debug) {
+            console.log("[vue-yandex-metrika] notBounce:", arguments);
+        }
+    }
+    params() {
+        if (this.config.debug) {
+            console.log("[vue-yandex-metrika] params:", arguments);
+        }
+    }
+    reachGoal() {
+        if (this.config.debug) {
+            console.log("[vue-yandex-metrika] reachGoal:", arguments);
+        }
+    }
+    replacePhones() {
+        if (this.config.debug) {
+            console.log("[vue-yandex-metrika] replacePhones:", arguments);
+        }
+    }
+    setUserID() {
+        if (this.config.debug) {
+            console.log("[vue-yandex-metrika] setUserID:", arguments);
+        }
+    }
+    userParams() {
+        if (this.config.debug) {
+            console.log("[vue-yandex-metrika] userParams:", arguments);
+        }
+    }
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 import { App } from "vue";
-import { EmptyYaMetrika } from "./empty-ya.js";
-import type { Config, YaMetrika } from "./types.js";
+import type { Config } from "./types.js";
+import { YaMetrikaObject } from "./ya-object.js";
 export declare function initYandexMetrika(app: App, options: Config): void;
-export declare function useYandexMetrika(): YaMetrika | EmptyYaMetrika;
+export declare function useYandexMetrika(): YaMetrikaObject;

--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,19 @@
 import { EmptyYaMetrika } from "./empty-ya.js";
 import { updateConfig, checkConfig, loadScript, createMetrika, startTracking, } from "./helpers.js";
-let _metrikaInstance = null;
+import { YaMetrikaObject } from "./ya-object.js";
+let _metrikaInstance = new YaMetrikaObject();
 export function initYandexMetrika(app, options) {
-    app.config.globalProperties.$yandexMetrika = new EmptyYaMetrika();
+    const emptyMetrika = new EmptyYaMetrika();
+    _metrikaInstance.setMetrika(emptyMetrika);
+    app.config.globalProperties.$yandexMetrika = _metrikaInstance;
     updateConfig(options);
     checkConfig();
     loadScript(() => {
-        _metrikaInstance = createMetrika(app);
+        const metrika = createMetrika(app);
+        _metrikaInstance.setMetrika(metrika);
         startTracking(_metrikaInstance);
     }, options.scriptSrc);
 }
 export function useYandexMetrika() {
-    if (_metrikaInstance) {
-        return _metrikaInstance;
-    }
-    else {
-        console.error("Yandex metrika has not been initialized");
-        return (_metrikaInstance = new EmptyYaMetrika());
-    }
+    return _metrikaInstance;
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -54,7 +54,7 @@ declare global {
         };
     }
 }
-declare interface SubParams {
+export declare interface SubParams {
     callback?: () => void;
     ctx?: any;
     params?: {

--- a/src/ya-object.d.ts
+++ b/src/ya-object.d.ts
@@ -1,0 +1,27 @@
+import { YaMetrika, SubParams } from "./types";
+export declare class YaMetrikaObject implements YaMetrika {
+    metrika: YaMetrika | null;
+    setMetrika(metrika: YaMetrika | null): void;
+    private _setFunctions;
+    addFileExtension(vals: string | string[]): void;
+    extLink(url: string, options?: SubParams | undefined): void;
+    file(url: string, options?: SubParams | undefined): void;
+    getClientID(callback: (clientID: string) => void): void;
+    hit(url: string, options?: SubParams | undefined): void;
+    notBounce(options?: {
+        callback: () => void;
+        ctx?: any;
+    } | undefined): void;
+    params(parameters: any[] | {
+        [key: string]: any;
+    }): void;
+    reachGoal(target: string, params?: {
+        order_price?: number | undefined;
+        currency?: string | undefined;
+    } | undefined, callback?: (() => void) | undefined, ctx?: any): void;
+    replacePhones(): void;
+    setUserID(userID: string): void;
+    userParams(parameters: {
+        [key: string]: any;
+    }): void;
+}

--- a/src/ya-object.js
+++ b/src/ya-object.js
@@ -11,17 +11,17 @@ export class YaMetrikaObject {
         if (!m) {
             return;
         }
-        this.addFileExtension = m.addFileExtension;
-        this.extLink = m.extLink;
-        this.file = m.file;
-        this.getClientID = m.getClientID;
-        this.hit = m.hit;
-        this.notBounce = m.notBounce;
-        this.params = m.params;
-        this.reachGoal = m.reachGoal;
-        this.replacePhones = m.replacePhones;
-        this.setUserID = m.setUserID;
-        this.userParams = m.userParams;
+        this.addFileExtension = m.addFileExtension.bind(m);
+        this.extLink = m.extLink.bind(m);
+        this.file = m.file.bind(m);
+        this.getClientID = m.getClientID.bind(m);
+        this.hit = m.hit.bind(m);
+        this.notBounce = m.notBounce.bind(m);
+        this.params = m.params.bind(m);
+        this.reachGoal = m.reachGoal.bind(m);
+        this.replacePhones = m.replacePhones.bind(m);
+        this.setUserID = m.setUserID.bind(m);
+        this.userParams = m.userParams.bind(m);
     }
     addFileExtension(vals) {
         throw new Error("Method not implemented.");

--- a/src/ya-object.js
+++ b/src/ya-object.js
@@ -7,21 +7,22 @@ export class YaMetrikaObject {
         this._setFunctions();
     }
     _setFunctions() {
+        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l;
         const m = this.metrika;
         if (!m) {
             return;
         }
-        this.addFileExtension = m.addFileExtension.bind(m);
-        this.extLink = m.extLink.bind(m);
-        this.file = m.file.bind(m);
-        this.getClientID = m.getClientID.bind(m);
-        this.hit = m.hit.bind(m);
-        this.notBounce = m.notBounce.bind(m);
-        this.params = m.params.bind(m);
-        this.reachGoal = m.reachGoal.bind(m);
-        this.replacePhones = m.replacePhones.bind(m);
-        this.setUserID = m.setUserID.bind(m);
-        this.userParams = m.userParams.bind(m);
+        this.addFileExtension = (_a = m.addFileExtension) === null || _a === void 0 ? void 0 : _a.bind(m);
+        this.extLink = (_b = m.extLink) === null || _b === void 0 ? void 0 : _b.bind(m);
+        this.file = (_c = m.file) === null || _c === void 0 ? void 0 : _c.bind(m);
+        this.getClientID = (_d = m.getClientID) === null || _d === void 0 ? void 0 : _d.bind(m);
+        this.hit = (_e = m.hit) === null || _e === void 0 ? void 0 : _e.bind(m);
+        this.notBounce = (_f = m.notBounce) === null || _f === void 0 ? void 0 : _f.bind(m);
+        this.params = (_g = m.params) === null || _g === void 0 ? void 0 : _g.bind(m);
+        this.reachGoal = (_h = m.reachGoal) === null || _h === void 0 ? void 0 : _h.bind(m);
+        this.replacePhones = (_j = m.replacePhones) === null || _j === void 0 ? void 0 : _j.bind(m);
+        this.setUserID = (_k = m.setUserID) === null || _k === void 0 ? void 0 : _k.bind(m);
+        this.userParams = (_l = m.userParams) === null || _l === void 0 ? void 0 : _l.bind(m);
     }
     addFileExtension(vals) {
         throw new Error("Method not implemented.");

--- a/src/ya-object.js
+++ b/src/ya-object.js
@@ -1,0 +1,59 @@
+export class YaMetrikaObject {
+    constructor() {
+        this.metrika = null;
+    }
+    setMetrika(metrika) {
+        this.metrika = metrika;
+        this._setFunctions();
+    }
+    _setFunctions() {
+        const m = this.metrika;
+        if (!m) {
+            return;
+        }
+        this.addFileExtension = m.addFileExtension;
+        this.extLink = m.extLink;
+        this.file = m.file;
+        this.getClientID = m.getClientID;
+        this.hit = m.hit;
+        this.notBounce = m.notBounce;
+        this.params = m.params;
+        this.reachGoal = m.reachGoal;
+        this.replacePhones = m.replacePhones;
+        this.setUserID = m.setUserID;
+        this.userParams = m.userParams;
+    }
+    addFileExtension(vals) {
+        throw new Error("Method not implemented.");
+    }
+    extLink(url, options) {
+        throw new Error("Method not implemented.");
+    }
+    file(url, options) {
+        throw new Error("Method not implemented.");
+    }
+    getClientID(callback) {
+        throw new Error("Method not implemented.");
+    }
+    hit(url, options) {
+        throw new Error("Method not implemented.");
+    }
+    notBounce(options) {
+        throw new Error("Method not implemented.");
+    }
+    params(parameters) {
+        throw new Error("Method not implemented.");
+    }
+    reachGoal(target, params, callback, ctx) {
+        throw new Error("Method not implemented.");
+    }
+    replacePhones() {
+        throw new Error("Method not implemented.");
+    }
+    setUserID(userID) {
+        throw new Error("Method not implemented.");
+    }
+    userParams(parameters) {
+        throw new Error("Method not implemented.");
+    }
+}


### PR DESCRIPTION
When using yandex metrika in script setup inside a nuxt page like so:

```ts
<script setup>
import { useYandexMetrika } from 'yandex-metrika-vue3'

const yandexMetrika = useYandexMetrika()

const onClick = () => {
    yandexMetrika.reachGoal('test')
}
</script>
```

There's an error in the console `Yandex metrika has not been initialized`.

([codesandbox example](https://codesandbox.io/p/sandbox/snowy-browser-y4mtdk?file=%2Fpages%2Findex.vue%3A7%2C35))


The error occurs because `useYandexMetrika` [logs an error and returns EmptyYaMetrika](https://github.com/kennardy/vue-yandex-metrika/blob/273ecdd05d80cee33137e48c1d3792c754352feb/lib/index.ts#L26-L33) if metrika isn't loaded. Consecutive calls to `useYandexMetrika` will return an `EmptyYaMetrika` instance without logging an error

After a while, actual metrika [is loaded](https://github.com/kennardy/vue-yandex-metrika/blob/273ecdd05d80cee33137e48c1d3792c754352feb/lib/index.ts#L21), and global `_metrikaInstance` is updated. 

However, `yandexMetrika` variable in `script setup` (the one that got called before yandex metrika script was fully loaded) will remain an instance of `EmptyYaMetrika`.

`yandexMetrika.reachGoal('test')` will not throw an error, and it will not send anything to yandex.

In this PR:

- created `YaMetrikaObject` - a proxy for an underlying yandex metrika implementation
- set `YaMetrikaObject`'s metrika to `EmptyYaMetrika` initially, and to actual metrika after it is loaded
- return `YaMetrikaObject` in `useYandexMetrika` 
- added `src/empty-ya.js`/`src/empty-ya.d.ts`, `src/ya-object.js`/`src/ya-object.d.ts` to git (not sure if they need to be added, but other files in `src` were)
