### PR TITLE
Allow using both `tag.js` and `watch.js`

### DIFF
--- a/lib/getMetrikaInstance.ts
+++ b/lib/getMetrikaInstance.ts
@@ -1,11 +1,38 @@
-import type { Config, YaMetrika } from "./types.js"
+import { EmptyYaMetrika } from "./empty-ya.js";
 
-export function getMetrikaInstance (config: Config | Record<string, any>): YaMetrika {
-    const instance = new window.Ya.Metrika2(config)
-    setMetrikaInstance(instance, config as Config)
-    return instance
+import type { Config, YaMetrika } from "./types.js";
+
+export function getMetrikaInstance(
+  config: Config | Record<string, any>,
+  params: {
+    /** If `true`, try using `Ya.Metrika` first */
+    tryMetrika1: boolean;
+  }
+): YaMetrika {
+  let instance: YaMetrika | undefined;
+
+  try {
+    const hasMetrika1 = window?.Ya && window.Ya.Metrika;
+
+    if (params.tryMetrika1 && hasMetrika1) {
+      instance = new window.Ya.Metrika(config);
+    } else {
+      instance = new window.Ya.Metrika2(config);
+    }
+  } catch (e) {
+    console.error("Error initializing yandex metrika: ", e);
+  }
+
+  if (!instance) {
+    console.error("No Metrika or Metrika2 in window.Ya");
+
+    instance = new EmptyYaMetrika() as YaMetrika;
+  }
+
+  setMetrikaInstance(instance, config as Config);
+  return instance;
 }
 
-function setMetrikaInstance (instance: YaMetrika, config: Config) {
-    window[`yaCounter${config.id}`] = instance
+function setMetrikaInstance(instance: YaMetrika, config: Config) {
+  window[`yaCounter${config.id}`] = instance;
 }

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -51,7 +51,9 @@ export function createMetrika(app: App): YaMetrika {
       id: config.id,
       ...config.options,
     };
-    let metrika = getMetrikaInstance(init);
+    let metrika = getMetrikaInstance(init, {
+      tryMetrika1: config.scriptSrc === "https://mc.yandex.ru/metrika/watch.js",
+    });
     return (app.config.globalProperties.$yandexMetrika = metrika);
   } else {
     // Mock metrika

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -24,6 +24,19 @@ export interface Options {
 interface YaOptions extends Options {
   id?: null | string;
 }
+
+/**
+ * Metrika script.
+ *
+ * `tag.js` is version 2,
+ * `watch.js` is version 1
+ *
+ * Differences: https://yandex.com/support/metrica/general/tag-info.html
+ */
+export type ScriptSrcTy =
+  | "https://mc.yandex.ru/metrika/tag.js"
+  | "https://mc.yandex.ru/metrika/watch.js";
+
 export interface Config {
   id?: null | string;
   options?: {
@@ -42,7 +55,7 @@ export interface Config {
     triggerEvent?: boolean;
   };
   router?: null | Router;
-  scriptSrc: "https://mc.yandex.ru/metrika/tag.js";
+  scriptSrc: ScriptSrcTy;
   debug?: boolean;
   env: string;
   ignoreRoutes?: Array<string>;
@@ -52,8 +65,9 @@ export interface Config {
 declare global {
   interface Window {
     [key: `yaCounter${string}`]: YaMetrika;
-  
+
     Ya: {
+      Metrika: YaMetrikaInit;
       Metrika2: YaMetrikaInit;
     };
   }

--- a/src/getMetrikaInstance.d.ts
+++ b/src/getMetrikaInstance.d.ts
@@ -1,2 +1,5 @@
 import type { Config, YaMetrika } from "./types.js";
-export declare function getMetrikaInstance(config: Config | Record<string, any>): YaMetrika;
+export declare function getMetrikaInstance(config: Config | Record<string, any>, params: {
+    /** If `true`, try using `Ya.Metrika` first */
+    tryMetrika1: boolean;
+}): YaMetrika;

--- a/src/getMetrikaInstance.js
+++ b/src/getMetrikaInstance.js
@@ -1,5 +1,22 @@
-export function getMetrikaInstance(config) {
-    const instance = new window.Ya.Metrika2(config);
+import { EmptyYaMetrika } from "./empty-ya.js";
+export function getMetrikaInstance(config, params) {
+    let instance;
+    try {
+        const hasMetrika1 = (window === null || window === void 0 ? void 0 : window.Ya) && window.Ya.Metrika;
+        if (params.tryMetrika1 && hasMetrika1) {
+            instance = new window.Ya.Metrika(config);
+        }
+        else {
+            instance = new window.Ya.Metrika2(config);
+        }
+    }
+    catch (e) {
+        console.error("Error initializing yandex metrika: ", e);
+    }
+    if (!instance) {
+        console.error("No Metrika or Metrika2 in window.Ya");
+        instance = new EmptyYaMetrika();
+    }
     setMetrikaInstance(instance, config);
     return instance;
 }

--- a/src/helpers.d.ts
+++ b/src/helpers.d.ts
@@ -2,6 +2,6 @@ import { App } from "vue";
 import type { YaMetrika } from "./types.js";
 export declare function updateConfig(params: Record<string, any>): void;
 export declare function checkConfig(): void;
-export declare function loadScript(callback: () => void, scriptSrc?: "https://mc.yandex.ru/metrika/tag.js"): void;
+export declare function loadScript(callback: () => void, scriptSrc?: import("./types.js").ScriptSrcTy): void;
 export declare function createMetrika(app: App): YaMetrika;
 export declare function startTracking(metrika: YaMetrika): void;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -33,7 +33,9 @@ export function createMetrika(app) {
     if (config.env === "production") {
         // Creates Metrika
         const init = Object.assign({ id: config.id }, config.options);
-        let metrika = getMetrikaInstance(init);
+        let metrika = getMetrikaInstance(init, {
+            tryMetrika1: config.scriptSrc === "https://mc.yandex.ru/metrika/watch.js",
+        });
         return (app.config.globalProperties.$yandexMetrika = metrika);
     }
     else {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -21,6 +21,15 @@ export interface Options {
 interface YaOptions extends Options {
     id?: null | string;
 }
+/**
+ * Metrika script.
+ *
+ * `tag.js` is version 2,
+ * `watch.js` is version 1
+ *
+ * Differences: https://yandex.com/support/metrica/general/tag-info.html
+ */
+export type ScriptSrcTy = "https://mc.yandex.ru/metrika/tag.js" | "https://mc.yandex.ru/metrika/watch.js";
 export interface Config {
     id?: null | string;
     options?: {
@@ -39,7 +48,7 @@ export interface Config {
         triggerEvent?: boolean;
     };
     router?: null | Router;
-    scriptSrc: "https://mc.yandex.ru/metrika/tag.js";
+    scriptSrc: ScriptSrcTy;
     debug?: boolean;
     env: string;
     ignoreRoutes?: Array<string>;
@@ -50,6 +59,7 @@ declare global {
     interface Window {
         [key: `yaCounter${string}`]: YaMetrika;
         Ya: {
+            Metrika: YaMetrikaInit;
             Metrika2: YaMetrikaInit;
         };
     }


### PR DESCRIPTION
Yandex supports [2 versions of metrika](https://yandex.ru/support/metrica/general/tag-info.html):

- tag.js (metrika version 2)
- watch.js (metrika version 1)

Allow using either version with this plugin

# Why

There was a memory leak with yandex webvisor 2.0 a month ago, and I needed to rollback from tag.js to watch.js

I'm not sure if the memory leak is fixed now

# Changes

- allow using `tag.js` (metrika 2) or `watch.js` (metrika) in config
- use `window.Ya.Metrika` as an instance for watch.js, 
  and `window.Ya.Metrika2` as instance for tag.js
