### PR TITLE
Global component properties pollution fixed

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -160,7 +160,7 @@ export declare class YaMetrika {
   userParams(parameters: { [key: string]: any }): void;
 }
 
-declare module "@vue/runtime-core" {
+declare module "vue" {
   interface VueConstructor {
     $yandexMetrika: YaMetrika;
   }


### PR DESCRIPTION
declare module "@vue/runtime-core" breaks all other packages that declare global vue properties (e.g. vue-18n). This change fixes it.